### PR TITLE
Fix Instagram link in Footer component

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -49,7 +49,7 @@ export function Footer() {
           <img src={GmailIcon} alt="gmail" />
         </a>
         <a
-          href="https://www.instagram.com/raghutelkar.in"
+          href="https://www.instagram.com/raghutelkar"
           target="_blank"
           rel="noreferrer"
         >


### PR DESCRIPTION
Updated the Instagram URL in the Footer component to remove the '.in' suffix, ensuring the link directs to the correct profile.